### PR TITLE
fix: always get the next available port when creating Docker containers

### DIFF
--- a/dockerutil/ports.go
+++ b/dockerutil/ports.go
@@ -3,7 +3,6 @@ package dockerutil
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"sync"
 
 	"github.com/docker/go-connections/nat"
@@ -42,7 +41,6 @@ func OpenListener(port int) (*net.TCPListener, error) {
 // This allows multiple GetPort calls to find multiple available ports
 // before closing them so they are available for the PortBinding.
 func GetPort(port int) (nat.PortBinding, *net.TCPListener, error) {
-	port = 0
 	l, err := OpenListener(port)
 	if err != nil {
 		l.Close()
@@ -67,17 +65,22 @@ func GeneratePortBindings(pairs nat.PortMap) (nat.PortMap, Listeners, error) {
 	var err error
 
 	for p, bind := range pairs {
-		if len(bind) == 0 {
-			// random port
-			pb, l, err = GetPort(0)
-		} else {
-			var pNum int
-			if pNum, err = strconv.Atoi(bind[0].HostPort); err != nil {
-				return nat.PortMap{}, nil, err
-			}
+		_ = bind
 
-			pb, l, err = GetPort(pNum)
-		}
+		// ALWAYS a random port
+		pb, l, err = GetPort(0)
+
+		// if len(bind) == 0 {
+		// 	// random port
+		// 	pb, l, err = GetPort(0)
+		// } else {
+		// 	var pNum int
+		// 	if pNum, err = strconv.Atoi(bind[0].HostPort); err != nil {
+		// 		return nat.PortMap{}, nil, err
+		// 	}
+
+		// 	pb, l, err = GetPort(pNum)
+		// }
 
 		if err != nil {
 			listeners.CloseAll()

--- a/dockerutil/ports.go
+++ b/dockerutil/ports.go
@@ -43,7 +43,10 @@ func OpenListener(port int) (*net.TCPListener, error) {
 func GetPort(port int) (nat.PortBinding, *net.TCPListener, error) {
 	l, err := OpenListener(port)
 	if err != nil {
-		l.Close()
+		if l != nil {
+			_ = l.Close()
+		}
+
 		return nat.PortBinding{}, nil, err
 	}
 

--- a/dockerutil/ports.go
+++ b/dockerutil/ports.go
@@ -42,6 +42,7 @@ func OpenListener(port int) (*net.TCPListener, error) {
 // This allows multiple GetPort calls to find multiple available ports
 // before closing them so they are available for the PortBinding.
 func GetPort(port int) (nat.PortBinding, *net.TCPListener, error) {
+	port = 0
 	l, err := OpenListener(port)
 	if err != nil {
 		l.Close()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Port allocation now always requests a random available port, ensuring consistent automatic assignment and reducing startup conflicts.
  * Removed conditional handling of user-provided port bindings so supplied port values are no longer used for allocation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->